### PR TITLE
Csk refactor

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/ItemStates.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/ItemStates.java
@@ -1,7 +1,0 @@
-package rabbitescape.engine.newstates;
-
-import rabbitescape.engine.NewStates;
-
-public abstract class ItemStates extends NewStates {
-
-}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Bashing.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Bashing.java
@@ -2,7 +2,6 @@ package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.ChangeDescription.State.*;
 import static rabbitescape.engine.Direction.*;
-import static rabbitescape.engine.things.items.ItemType.*;
 
 import java.util.Map;
 
@@ -12,6 +11,7 @@ import rabbitescape.engine.newstates.CharacterStates;
 import rabbitescape.engine.newstates.characterstates.CharacterActionStates;
 import rabbitescape.engine.newstates.characterstates.actions.bashing.*;
 import rabbitescape.engine.things.Character;
+import rabbitescape.engine.things.items.BashItem;
 
 public class Bashing extends CharacterActionStates {
 
@@ -52,7 +52,7 @@ public class Bashing extends CharacterActionStates {
     public boolean checkTriggered(Character character, World world) {
         BehaviourTools t = new BehaviourTools(character, world);
 
-        return t.pickUpToken(bash);
+        return t.pickUpToken(BashItem.TYPE);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Blocking.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Blocking.java
@@ -1,7 +1,6 @@
 package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.ChangeDescription.State.*;
-import static rabbitescape.engine.things.items.ItemType.*;
 
 import java.util.Map;
 
@@ -10,6 +9,7 @@ import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.newstates.characterstates.CharacterActionStates;
 import rabbitescape.engine.newstates.characterstates.actions.blocking.*;
 import rabbitescape.engine.things.Character;
+import rabbitescape.engine.things.items.BlockItem;
 
 public class Blocking extends CharacterActionStates {
 
@@ -32,7 +32,7 @@ public class Blocking extends CharacterActionStates {
     @Override
     public boolean checkTriggered(Character character, World world) {
         BehaviourTools t = new BehaviourTools(character, world);
-        return t.pickUpToken(block);
+        return t.pickUpToken(BlockItem.TYPE);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Bridging.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Bridging.java
@@ -2,7 +2,6 @@ package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.Block.Material.EARTH;
 import static rabbitescape.engine.Direction.RIGHT;
-import static rabbitescape.engine.things.items.ItemType.*;
 import static rabbitescape.engine.Block.Shape.*;
 
 import java.util.Map;
@@ -15,6 +14,7 @@ import rabbitescape.engine.newstates.characterstates.actions.bridging.bridging1.
 import rabbitescape.engine.newstates.characterstates.actions.bridging.bridging2.*;
 import rabbitescape.engine.newstates.characterstates.actions.bridging.bridging3.*;
 import rabbitescape.engine.things.Character;
+import rabbitescape.engine.things.items.BridgeItem;
 
 public class Bridging extends CharacterActionStates {
 
@@ -74,7 +74,7 @@ public class Bridging extends CharacterActionStates {
 
             if (possibleState != null) // Only pick up if we can bridge
             {
-                return t.pickUpToken(bridge);
+                return t.pickUpToken(BridgeItem.TYPE);
             }
         }
         return false;

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Brollychuting.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Brollychuting.java
@@ -2,7 +2,6 @@ package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.ChangeDescription.State.*;
 import static rabbitescape.engine.Direction.RIGHT;
-import static rabbitescape.engine.things.items.ItemType.brolly;
 
 import java.util.Map;
 
@@ -17,6 +16,7 @@ import rabbitescape.engine.newstates.characterstates.actions.brollychuting.IBrol
 import rabbitescape.engine.newstates.characterstates.actions.brollychuting.NotBrollychuting;
 import rabbitescape.engine.things.Character;
 import rabbitescape.engine.World;
+import rabbitescape.engine.things.items.BrollyItem;
 
 public class Brollychuting extends CharacterActionStates {
 
@@ -98,7 +98,7 @@ public class Brollychuting extends CharacterActionStates {
     public boolean checkTriggered(Character character, World world) {
         BehaviourTools t = new BehaviourTools(character, world);
 
-        if (!hasAbility && t.pickUpToken(brolly, true)) {
+        if (!hasAbility && t.pickUpToken(BrollyItem.TYPE, true)) {
             return true;
         }
 

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Climbing.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Climbing.java
@@ -2,7 +2,6 @@ package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.ChangeDescription.State.*;
 import static rabbitescape.engine.Direction.*;
-import static rabbitescape.engine.things.items.ItemType.*;
 
 import java.util.Map;
 
@@ -13,6 +12,7 @@ import rabbitescape.engine.newstates.characterstates.CharacterActionStates;
 import rabbitescape.engine.newstates.characterstates.actions.climbing.IClimbingState;
 import rabbitescape.engine.newstates.characterstates.actions.climbing.NotClimbing;
 import rabbitescape.engine.things.Character;
+import rabbitescape.engine.things.items.ClimbItem;
 
 public class Climbing extends CharacterActionStates {
 
@@ -49,7 +49,7 @@ public class Climbing extends CharacterActionStates {
     public boolean checkTriggered(Character character, World world) {
         BehaviourTools t = new BehaviourTools(character, world);
 
-        return !hasAbility && t.pickUpToken(climb, true);
+        return !hasAbility && t.pickUpToken(ClimbItem.TYPE, true);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Digging.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/characterstates/actions/Digging.java
@@ -1,7 +1,6 @@
 package rabbitescape.engine.newstates.characterstates.actions;
 
 import static rabbitescape.engine.ChangeDescription.State.*;
-import static rabbitescape.engine.things.items.ItemType.*;
 
 import java.util.Map;
 
@@ -11,6 +10,7 @@ import rabbitescape.engine.newstates.CharacterStates;
 import rabbitescape.engine.newstates.characterstates.CharacterActionStates;
 import rabbitescape.engine.newstates.characterstates.actions.digging.*;
 import rabbitescape.engine.things.Character;
+import rabbitescape.engine.things.items.DigItem;
 
 public class Digging extends CharacterActionStates {
 
@@ -33,7 +33,7 @@ public class Digging extends CharacterActionStates {
     @Override
     public boolean checkTriggered(Character character, World world) {
         BehaviourTools t = new BehaviourTools(character, world);
-        return t.pickUpToken(dig);
+        return t.pickUpToken(DigItem.TYPE);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/ItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/ItemState.java
@@ -1,0 +1,17 @@
+package rabbitescape.engine.newstates.item_states;
+
+import rabbitescape.engine.BehaviourTools;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.NewStates;
+
+public abstract class ItemState extends NewStates {
+
+    @Override
+    public State newState(BehaviourTools t, boolean triggered) {
+        return null;
+    }
+
+    public abstract ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope);
+
+    public abstract boolean isFalling();
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bash;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BashFallToSlope extends BashItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BASH_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bash;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BashFalling extends BashItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BASH_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashItemState.java
@@ -1,0 +1,23 @@
+package rabbitescape.engine.newstates.item_states.bash;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class BashItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new BashOnSlop();
+        } else if (!isMoving) {
+            newState = new BashStill();
+        } else if (isSlopeBelow) {
+            newState = new BashFallToSlope();
+        } else {
+            newState = new BashFalling();
+        }
+
+        return newState;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bash;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BashOnSlop extends BashItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BASH_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bash/BashStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bash;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BashStill extends BashItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BASH_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.block;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BlockFallToSlope extends BlockItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BLOCK_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.block;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BlockFalling extends BlockItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BLOCK_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.block;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class BlockItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new BlockOnSlop();
+        } else if (!isMoving) {
+            newState = new BlockStill();
+        } else if (isSlopeBelow) {
+            newState = new BlockFallToSlope();
+        } else {
+            newState = new BlockFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.block;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BlockOnSlop extends BlockItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BLOCK_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/block/BlockStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.block;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BlockStill extends BlockItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BLOCK_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bridge;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BridgeFallToSlope extends BridgeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BRIDGE_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bridge;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BridgeFalling extends BridgeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BRIDGE_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.bridge;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class BridgeItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new BridgeOnSlop();
+        } else if (!isMoving) {
+            newState = new BridgeStill();
+        } else if (isSlopeBelow) {
+            newState = new BridgeFallToSlope();
+        } else {
+            newState = new BridgeFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bridge;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BridgeOnSlop extends BridgeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BRIDGE_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/bridge/BridgeStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.bridge;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BridgeStill extends BridgeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BRIDGE_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.brolly;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BrollyFallToSlope extends BrollyItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BROLLY_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.brolly;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BrollyFalling extends BrollyItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BROLLY_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.brolly;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class BrollyItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new BrollyOnSlop();
+        } else if (!isMoving) {
+            newState = new BrollyStill();
+        } else if (isSlopeBelow) {
+            newState = new BrollyFallToSlope();
+        } else {
+            newState = new BrollyFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.brolly;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BrollyOnSlop extends BrollyItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BROLLY_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/brolly/BrollyStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.brolly;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class BrollyStill extends BrollyItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_BROLLY_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.climb;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ClimbFallToSlope extends ClimbItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_CLIMB_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.climb;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ClimbFalling extends ClimbItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_CLIMB_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.climb;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class ClimbItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new ClimbOnSlop();
+        } else if (!isMoving) {
+            newState = new ClimbStill();
+        } else if (isSlopeBelow) {
+            newState = new ClimbFallToSlope();
+        } else {
+            newState = new ClimbFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.climb;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ClimbOnSlop extends ClimbItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_CLIMB_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/climb/ClimbStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.climb;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ClimbStill extends ClimbItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_CLIMB_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.dig;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class DigFallToSlope extends DigItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_DIG_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.dig;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class DigFalling extends DigItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_DIG_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.dig;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class DigItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new DigOnSlop();
+        } else if (!isMoving) {
+            newState = new DigStill();
+        } else if (isSlopeBelow) {
+            newState = new DigFallToSlope();
+        } else {
+            newState = new DigFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.dig;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class DigOnSlop extends DigItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_DIG_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/dig/DigStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.dig;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class DigStill extends DigItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_DIG_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeFallToSlope.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeFallToSlope.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.explode;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ExplodeFallToSlope extends ExplodeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_EXPLODE_FALL_TO_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeFalling.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeFalling.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.explode;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ExplodeFalling extends ExplodeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_EXPLODE_FALLING;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return true;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeItemState.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeItemState.java
@@ -1,0 +1,24 @@
+package rabbitescape.engine.newstates.item_states.explode;
+
+import rabbitescape.engine.newstates.item_states.ItemState;
+
+public abstract class ExplodeItemState extends ItemState {
+
+    @Override
+    public ItemState newState(boolean isMoving, boolean isSlopeBelow, boolean isOnSlope) {
+        ItemState newState;
+
+        if (isOnSlope) {
+            newState = new ExplodeOnSlop();
+        } else if (!isMoving) {
+            newState = new ExplodeStill();
+        } else if (isSlopeBelow) {
+            newState = new ExplodeFallToSlope();
+        } else {
+            newState = new ExplodeFalling();
+        }
+
+        return newState;
+    }
+
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeOnSlop.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeOnSlop.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.explode;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ExplodeOnSlop extends ExplodeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_EXPLODE_ON_SLOPE;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeStill.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/newstates/item_states/explode/ExplodeStill.java
@@ -1,0 +1,16 @@
+package rabbitescape.engine.newstates.item_states.explode;
+
+import rabbitescape.engine.ChangeDescription.State;
+
+public class ExplodeStill extends ExplodeItemState {
+
+    @Override
+    public State getState() {
+        return State.TOKEN_EXPLODE_STILL;
+    }
+
+    @Override
+    public boolean isFalling() {
+        return false;
+    }
+}

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BashItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BashItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class BashItem extends Item {
 
-    private static final ItemType type = ItemType.bash;
+    public static final ItemType TYPE = ItemType.bash;
 
     public BashItem(int x, int y) {
-        super(x, y, State.TOKEN_BASH_ON_SLOPE, type);
+        super(x, y, State.TOKEN_BASH_ON_SLOPE, TYPE );
     }
 
     public BashItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BASH_ON_SLOPE, type, world);
+        super(x, y, State.TOKEN_BASH_ON_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BashItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BashItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.bash.BashFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class BashItem extends Item {
 
     public static final ItemType TYPE = ItemType.bash;
+    public static final ItemState DEFAULT_STATE = new BashFallToSlope();
 
     public BashItem(int x, int y) {
-        super(x, y, State.TOKEN_BASH_ON_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public BashItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BASH_ON_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'b';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_BASH_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_BASH_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_BASH_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_BASH_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BlockItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BlockItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class BlockItem extends Item {
 
-    private static final ItemType type = ItemType.block;
+    public static final ItemType TYPE = ItemType.block;
 
     public BlockItem(int x, int y) {
-        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, TYPE );
     }
 
     public BlockItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BlockItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BlockItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.block.BlockFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class BlockItem extends Item {
 
     public static final ItemType TYPE = ItemType.block;
+    public static final ItemState DEFAULT_STATE = new BlockFallToSlope();
 
     public BlockItem(int x, int y) {
-        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public BlockItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BLOCK_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'k';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_BLOCK_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_BLOCK_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_BLOCK_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_BLOCK_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BridgeItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BridgeItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class BridgeItem extends Item {
 
-    private static final ItemType type = ItemType.bridge;
+    public static final ItemType TYPE = ItemType.bridge;
 
     public BridgeItem(int x, int y) {
-        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, TYPE );
     }
 
     public BridgeItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BridgeItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BridgeItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.bridge.BridgeFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class BridgeItem extends Item {
 
     public static final ItemType TYPE = ItemType.bridge;
+    public static final ItemState DEFAULT_STATE = new BridgeFallToSlope();
 
     public BridgeItem(int x, int y) {
-        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public BridgeItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BRIDGE_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'i';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_BRIDGE_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_BRIDGE_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_BRIDGE_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_BRIDGE_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BrollyItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BrollyItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.brolly.BrollyFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class BrollyItem extends Item {
 
     public static final ItemType TYPE = ItemType.brolly;
+    public static final ItemState DEFAULT_STATE = new BrollyFallToSlope();
 
     public BrollyItem(int x, int y) {
-        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public BrollyItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'l';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_BROLLY_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_BROLLY_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_BROLLY_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_BROLLY_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/BrollyItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/BrollyItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class BrollyItem extends Item {
 
-    private static final ItemType type = ItemType.brolly;
+    public static final ItemType TYPE = ItemType.brolly;
 
     public BrollyItem(int x, int y) {
-        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, TYPE );
     }
 
     public BrollyItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_BROLLY_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/ClimbItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/ClimbItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.climb.ClimbFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class ClimbItem extends Item {
 
     public static final ItemType TYPE = ItemType.climb;
+    public static final ItemState DEFAULT_STATE = new ClimbFallToSlope();
 
     public ClimbItem(int x, int y) {
-        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public ClimbItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'c';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_CLIMB_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_CLIMB_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_CLIMB_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_CLIMB_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/ClimbItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/ClimbItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class ClimbItem extends Item {
 
-    private static final ItemType type = ItemType.climb;
+    public static final ItemType TYPE = ItemType.climb;
 
     public ClimbItem(int x, int y) {
-        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, TYPE );
     }
 
     public ClimbItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_CLIMB_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/DigItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/DigItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.dig.DigFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class DigItem extends Item {
 
     public static final ItemType TYPE = ItemType.dig;
+    public static final ItemState DEFAULT_STATE = new DigFallToSlope();
 
     public DigItem(int x, int y) {
-        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public DigItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'd';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_DIG_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_DIG_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_DIG_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_DIG_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/DigItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/DigItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class DigItem extends Item {
 
-    private static final ItemType type = ItemType.dig;
+    public static final ItemType TYPE = ItemType.dig;
 
     public DigItem(int x, int y) {
-        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, TYPE );
     }
 
     public DigItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_DIG_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/ExplodeItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/ExplodeItem.java
@@ -1,44 +1,26 @@
 package rabbitescape.engine.things.items;
 
-import rabbitescape.engine.ChangeDescription.State;
 import rabbitescape.engine.World;
+import rabbitescape.engine.newstates.item_states.ItemState;
+import rabbitescape.engine.newstates.item_states.explode.ExplodeFallToSlope;
 import rabbitescape.engine.things.Item;
 
 public class ExplodeItem extends Item {
 
     public static final ItemType TYPE = ItemType.explode;
+    public static final ItemState DEFAULT_STATE = new ExplodeFallToSlope();
 
     public ExplodeItem(int x, int y) {
-        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, TYPE );
+        super(x, y, DEFAULT_STATE, TYPE);
     }
 
     public ExplodeItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, TYPE, world);
+        super(x, y, DEFAULT_STATE, TYPE, world);
     }
 
     @Override
     public char getCharRepresentation() {
         return 'p';
-    }
-
-    @Override
-    public State getStillState() {
-        return State.TOKEN_EXPLODE_STILL;
-    }
-
-    @Override
-    public State getFallingState() {
-        return State.TOKEN_EXPLODE_FALLING;
-    }
-
-    @Override
-    public State getFallToSlopState() {
-        return State.TOKEN_EXPLODE_FALL_TO_SLOPE;
-    }
-
-    @Override
-    public State getOnSlopeState() {
-        return State.TOKEN_EXPLODE_ON_SLOPE;
     }
 
     @Override

--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/ExplodeItem.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/ExplodeItem.java
@@ -6,14 +6,14 @@ import rabbitescape.engine.things.Item;
 
 public class ExplodeItem extends Item {
 
-    private static final ItemType type = ItemType.explode;
+    public static final ItemType TYPE = ItemType.explode;
 
     public ExplodeItem(int x, int y) {
-        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, type);
+        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, TYPE );
     }
 
     public ExplodeItem(int x, int y, World world) {
-        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, type, world);
+        super(x, y, State.TOKEN_EXPLODE_FALL_TO_SLOPE, TYPE, world);
     }
 
     @Override


### PR DESCRIPTION
**Changed Item.type(private) to Item.TYPE(public)**
- replaced ItemType.xxx to XxxItem.TYPE


**Refactored each items' State Enums into a class**
Item.java
- removed state decision related methods to each XxxItemStates

XxxItemStates
- has default newState() decision-making method (can be overridden by subclasses)

XxxFalling/XxxFallToSlope/XxxOnSlop/XxxStill.java
- contains the related enum