### PR TITLE
Added test cases for Items

### DIFF
--- a/rabbit-escape-engine/src/rabbitescape/engine/things/items/ItemType.java
+++ b/rabbit-escape-engine/src/rabbitescape/engine/things/items/ItemType.java
@@ -1,6 +1,7 @@
 package rabbitescape.engine.things.items;
 
 public enum ItemType {
+    empty,
     bash,
     dig,
     bridge,

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/bash/BashItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/bash/BashItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.bash;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class BashItemStateTest {
+
+    public static final State STILL = State.TOKEN_BASH_STILL;
+    public static final State FALLING = State.TOKEN_BASH_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_BASH_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_BASH_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new BashStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new BashStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BashOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BashFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new BashFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/block/BlockItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/block/BlockItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.block;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class BlockItemStateTest {
+
+    public static final State STILL = State.TOKEN_BLOCK_STILL;
+    public static final State FALLING = State.TOKEN_BLOCK_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_BLOCK_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_BLOCK_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new BlockStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new BlockStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BlockOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BlockFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new BlockFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/bridge/BridgeItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/bridge/BridgeItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.bridge;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class BridgeItemStateTest {
+
+    public static final State STILL = State.TOKEN_BRIDGE_STILL;
+    public static final State FALLING = State.TOKEN_BRIDGE_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_BRIDGE_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_BRIDGE_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() throws Exception {
+        itemState = new BridgeStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new BridgeStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BridgeOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BridgeFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new BridgeFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/brolly/BrollyItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/brolly/BrollyItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.brolly;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class BrollyItemStateTest {
+
+    public static final State STILL = State.TOKEN_BROLLY_STILL;
+    public static final State FALLING = State.TOKEN_BROLLY_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_BROLLY_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_BROLLY_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new BrollyStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new BrollyStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BrollyOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new BrollyFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new BrollyFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/climb/ClimbItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/climb/ClimbItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.climb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class ClimbItemStateTest {
+
+    public static final State STILL = State.TOKEN_CLIMB_STILL;
+    public static final State FALLING = State.TOKEN_CLIMB_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_CLIMB_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_CLIMB_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new ClimbStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new ClimbStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new ClimbOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new ClimbFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new ClimbFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/dig/DigItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/dig/DigItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.dig;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class DigItemStateTest {
+
+    public static final State STILL = State.TOKEN_DIG_STILL;
+    public static final State FALLING = State.TOKEN_DIG_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_DIG_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_DIG_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new DigStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new DigStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new DigOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new DigFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new DigFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/explode/ExplodeItemStateTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/new_states/item_states/explode/ExplodeItemStateTest.java
@@ -1,0 +1,86 @@
+package rabbitescape.engine.new_states.item_states.explode;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.new_states.ItemState;
+
+public class ExplodeItemStateTest {
+
+    public static final State STILL = State.TOKEN_EXPLODE_STILL;
+    public static final State FALLING = State.TOKEN_EXPLODE_FALLING;
+    public static final State FALL_TO_SLOPE = State.TOKEN_EXPLODE_FALL_TO_SLOPE;
+    public static final State ON_SLOPE = State.TOKEN_EXPLODE_ON_SLOPE;
+    private ItemState itemState;
+
+    @Before
+    public void setUp() {
+        itemState = new ExplodeStill();
+    }
+
+    @Test
+    public void newState() {
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(FALLING, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(true);
+        itemState = itemState.newState();
+
+        assertEquals(FALL_TO_SLOPE, itemState.getState());
+
+        itemState.setMoving(false);
+        itemState.setOnSlope(false);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(STILL, itemState.getState());
+
+        itemState.setMoving(true);
+        itemState.setOnSlope(true);
+        itemState.setSlopeBelow(false);
+        itemState = itemState.newState();
+
+        assertEquals(ON_SLOPE, itemState.getState());
+    }
+
+    @Test
+    public void isMoving() {
+        assertFalse(itemState.isMoving());
+        assertFalse(itemState.isOnSlope());
+        assertFalse(itemState.isSlopeBelow());
+
+        itemState.setMoving(true);
+        assertTrue(itemState.isMoving());
+
+        itemState.setOnSlope(true);
+        assertTrue(itemState.isOnSlope());
+
+        itemState.setSlopeBelow(true);
+        assertTrue(itemState.isSlopeBelow());
+    }
+
+    @Test
+    public void isFalling() {
+        itemState = new ExplodeStill();
+        assertFalse(itemState.isFalling());
+
+        itemState = new ExplodeOnSlope();
+        assertFalse(itemState.isFalling());
+
+        itemState = new ExplodeFalling();
+        assertTrue(itemState.isFalling());
+
+        itemState = new ExplodeFallToSlope();
+        assertTrue(itemState.isFalling());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/ItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/ItemTest.java
@@ -1,0 +1,8 @@
+package rabbitescape.engine.things;
+
+public class ItemTest {
+
+    public static boolean isEqual(Item item1, Item item2) {
+        return item1.x == item2.x && item1.y == item2.y;
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/BashItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/BashItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BASH_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BASH_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class BashItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'b';
+    public static final String TYPE_NAME = "bash";
+    public static final State FALLING = TOKEN_BASH_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_BASH_FALL_TO_SLOPE;
+    private BashItem item;
+    private BashItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new BashItem(X, Y);
+        itemWithWorld = new BashItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(BashItem.TYPE, item.getType());
+        assertEquals(BashItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/BlockItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/BlockItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BLOCK_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BLOCK_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class BlockItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'k';
+    public static final String TYPE_NAME = "block";
+    public static final State FALLING = TOKEN_BLOCK_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_BLOCK_FALL_TO_SLOPE;
+    private BlockItem item;
+    private BlockItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new BlockItem(X, Y);
+        itemWithWorld = new BlockItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(BlockItem.TYPE, item.getType());
+        assertEquals(BlockItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/BridgeItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/BridgeItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BRIDGE_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BRIDGE_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class BridgeItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'i';
+    public static final String TYPE_NAME = "bridge";
+    public static final State FALLING = TOKEN_BRIDGE_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_BRIDGE_FALL_TO_SLOPE;
+    private BridgeItem item;
+    private BridgeItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new BridgeItem(X, Y);
+        itemWithWorld = new BridgeItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(BridgeItem.TYPE, item.getType());
+        assertEquals(BridgeItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/BrollyItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/BrollyItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BROLLY_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_BROLLY_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class BrollyItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'l';
+    public static final String TYPE_NAME = "brolly";
+    public static final State FALLING = TOKEN_BROLLY_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_BROLLY_FALL_TO_SLOPE;
+    private BrollyItem item;
+    private BrollyItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new BrollyItem(X, Y);
+        itemWithWorld = new BrollyItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(BrollyItem.TYPE, item.getType());
+        assertEquals(BrollyItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/ClimbItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/ClimbItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_CLIMB_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_CLIMB_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class ClimbItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'c';
+    public static final String TYPE_NAME = "climb";
+    public static final State FALLING = TOKEN_CLIMB_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_CLIMB_FALL_TO_SLOPE;
+    private ClimbItem item;
+    private ClimbItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new ClimbItem(X, Y);
+        itemWithWorld = new ClimbItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(ClimbItem.TYPE, item.getType());
+        assertEquals(ClimbItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/DigItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/DigItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_DIG_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_DIG_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class DigItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'd';
+    public static final String TYPE_NAME = "dig";
+    public static final State FALLING = TOKEN_DIG_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_DIG_FALL_TO_SLOPE;
+    private DigItem item;
+    private DigItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new DigItem(X, Y);
+        itemWithWorld = new DigItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(DigItem.TYPE, item.getType());
+        assertEquals(DigItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/ExplodeItemTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/ExplodeItemTest.java
@@ -1,0 +1,110 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_EXPLODE_FALLING;
+import static rabbitescape.engine.ChangeDescription.State.TOKEN_EXPLODE_FALL_TO_SLOPE;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import rabbitescape.engine.ChangeDescription.State;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class ExplodeItemTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    public static final char CHARACTER_REPRESENT = 'p';
+    public static final String TYPE_NAME = "explode";
+    public static final State FALLING = TOKEN_EXPLODE_FALLING;
+    public static final State FALL_TO_SLOPE = TOKEN_EXPLODE_FALL_TO_SLOPE;
+    private ExplodeItem item;
+    private ExplodeItem itemWithWorld;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Before
+    public void setUp() {
+        item = new ExplodeItem(X, Y);
+        itemWithWorld = new ExplodeItem(X, Y, emptyWorld);
+    }
+
+    @Test
+    public void getCharRepresentation() {
+        assertEquals(CHARACTER_REPRESENT, item.getCharRepresentation());
+        assertEquals(CHARACTER_REPRESENT, itemWithWorld.getCharRepresentation());
+    }
+
+    @Test
+    public void copyWithoutState() {
+        Item copy1 = item.copyWithoutState();
+        Item copy2 = itemWithWorld.copyWithoutState();
+
+        assertTrue(ItemTest.isEqual(copy1, copy2));
+    }
+
+    @Test
+    public void getType() {
+        assertEquals(ExplodeItem.TYPE, item.getType());
+        assertEquals(ExplodeItem.TYPE, itemWithWorld.getType());
+    }
+
+    @Test
+    public void calcNewSate() {
+        item.calcNewState(emptyWorld);
+        assertEquals(FALLING, item.state);
+    }
+
+    @Test
+    public void step() {
+        assertEquals(Y, item.y);
+        item.step(emptyWorld);
+        assertEquals(Y + 1, item.y);
+
+        assertEquals(Y, itemWithWorld.y);
+        itemWithWorld.step(emptyWorld);
+        assertEquals(Y + 1, itemWithWorld.y);
+    }
+
+    @Test
+    public void stepOutsideWorld() {
+        item.y = emptyWorld.size.height;
+        item.step(emptyWorld);
+        assertTrue(item.y >= emptyWorld.size.height);
+
+        itemWithWorld.y = emptyWorld.size.height;
+        itemWithWorld.step(emptyWorld);
+        assertTrue(itemWithWorld.y >= emptyWorld.size.height);
+    }
+
+    @Test
+    public void saveState() {
+        final Map<String, String> map = item.saveState(false);
+        final Map<String, String> mapWithWorld = itemWithWorld.saveState(false);
+
+        assertTrue(map instanceof HashMap);
+        assertTrue(map.isEmpty());
+
+        assertTrue(mapWithWorld instanceof HashMap);
+        assertTrue(mapWithWorld.isEmpty());
+    }
+
+    @Test
+    public void restoreFromState() {
+        item.restoreFromState(null);
+        assertEquals(FALL_TO_SLOPE, item.state);
+
+        itemWithWorld.restoreFromState(null);
+        assertEquals(FALLING, itemWithWorld.state);
+    }
+
+    @Test
+    public void overlayText() {
+        assertEquals(TYPE_NAME, item.overlayText());
+        assertEquals(TYPE_NAME, itemWithWorld.overlayText());
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/ItemFactoryTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/ItemFactoryTest.java
@@ -1,0 +1,88 @@
+package rabbitescape.engine.things.items;
+
+import static junit.framework.TestCase.assertTrue;
+
+import org.junit.Test;
+import rabbitescape.engine.World;
+import rabbitescape.engine.textworld.TextWorldManip;
+import rabbitescape.engine.things.Item;
+import rabbitescape.engine.things.ItemTest;
+
+public class ItemFactoryTest {
+
+    public static final int X = 10;
+    public static final int Y = 20;
+    private World emptyWorld = TextWorldManip.createEmptyWorld(100, 100);
+
+    @Test
+    public void createItem() {
+        Item bash = ItemFactory.createItem(X, Y, BashItem.TYPE);
+        Item dig = ItemFactory.createItem(X, Y, DigItem.TYPE);
+        Item bridge = ItemFactory.createItem(X, Y, BridgeItem.TYPE);
+        Item block = ItemFactory.createItem(X, Y, BlockItem.TYPE);
+        Item climb = ItemFactory.createItem(X, Y, ClimbItem.TYPE);
+        Item explode = ItemFactory.createItem(X, Y, ExplodeItem.TYPE);
+        Item brolly = ItemFactory.createItem(X, Y, BrollyItem.TYPE);
+
+        assertTrue(ItemTest.isEqual(new BashItem(X, Y), bash));
+        assertTrue(ItemTest.isEqual(new DigItem(X, Y), dig));
+        assertTrue(ItemTest.isEqual(new BridgeItem(X, Y), bridge));
+        assertTrue(ItemTest.isEqual(new BlockItem(X, Y), block));
+        assertTrue(ItemTest.isEqual(new ClimbItem(X, Y), climb));
+        assertTrue(ItemTest.isEqual(new ExplodeItem(X, Y), explode));
+        assertTrue(ItemTest.isEqual(new BrollyItem(X, Y), brolly));
+    }
+
+    @Test(expected = UnknownItemTypeException.class)
+    public void createEmptyItem() {
+        ItemFactory.createItem(X, Y, ItemType.empty);
+    }
+
+    @Test
+    public void createItemWithWorld() {
+        Item bash = ItemFactory.createItem(X, Y, BashItem.TYPE, emptyWorld);
+        Item dig = ItemFactory.createItem(X, Y, DigItem.TYPE, emptyWorld);
+        Item bridge = ItemFactory.createItem(X, Y, BridgeItem.TYPE, emptyWorld);
+        Item block = ItemFactory.createItem(X, Y, BlockItem.TYPE, emptyWorld);
+        Item climb = ItemFactory.createItem(X, Y, ClimbItem.TYPE, emptyWorld);
+        Item explode = ItemFactory.createItem(X, Y, ExplodeItem.TYPE, emptyWorld);
+        Item brolly = ItemFactory.createItem(X, Y, BrollyItem.TYPE, emptyWorld);
+
+        assertTrue(ItemTest.isEqual(new BashItem(X, Y, emptyWorld), bash));
+        assertTrue(ItemTest.isEqual(new DigItem(X, Y, emptyWorld), dig));
+        assertTrue(ItemTest.isEqual(new BridgeItem(X, Y, emptyWorld), bridge));
+        assertTrue(ItemTest.isEqual(new BlockItem(X, Y, emptyWorld), block));
+        assertTrue(ItemTest.isEqual(new ClimbItem(X, Y, emptyWorld), climb));
+        assertTrue(ItemTest.isEqual(new ExplodeItem(X, Y, emptyWorld), explode));
+        assertTrue(ItemTest.isEqual(new BrollyItem(X, Y, emptyWorld), brolly));
+    }
+
+    @Test(expected = UnknownItemTypeException.class)
+    public void createEmptyItemWithWorld() {
+        ItemFactory.createItem(X, Y, ItemType.empty, emptyWorld);
+    }
+
+    @Test
+    public void createItemByCharacter() {
+        Item bash = ItemFactory.createItem(X, Y, 'b');
+        Item dig = ItemFactory.createItem(X, Y, 'd');
+        Item bridge = ItemFactory.createItem(X, Y, 'i');
+        Item block = ItemFactory.createItem(X, Y, 'k');
+        Item climb = ItemFactory.createItem(X, Y, 'c');
+        Item explode = ItemFactory.createItem(X, Y, 'p');
+        Item brolly = ItemFactory.createItem(X, Y, 'l');
+
+        assertTrue(ItemTest.isEqual(new BashItem(X, Y), bash));
+        assertTrue(ItemTest.isEqual(new DigItem(X, Y), dig));
+        assertTrue(ItemTest.isEqual(new BridgeItem(X, Y), bridge));
+        assertTrue(ItemTest.isEqual(new BlockItem(X, Y), block));
+        assertTrue(ItemTest.isEqual(new ClimbItem(X, Y), climb));
+        assertTrue(ItemTest.isEqual(new ExplodeItem(X, Y), explode));
+        assertTrue(ItemTest.isEqual(new BrollyItem(X, Y), brolly));
+    }
+
+    @Test(expected = UnknownCharRepresentationException.class)
+    public void invalidType() {
+        ItemFactory.createItem(X, Y, 'z');
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/ItemTypeTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/ItemTypeTest.java
@@ -1,0 +1,19 @@
+package rabbitescape.engine.things.items;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class ItemTypeTest {
+
+    @Test
+    public void name() {
+        assertEquals("Bash", ItemType.name(ItemType.bash));
+        assertEquals("Dig", ItemType.name(ItemType.dig));
+        assertEquals("Bridge", ItemType.name(ItemType.bridge));
+        assertEquals("Block", ItemType.name(ItemType.block));
+        assertEquals("Climb", ItemType.name(ItemType.climb));
+        assertEquals("Explode", ItemType.name(ItemType.explode));
+        assertEquals("Brolly", ItemType.name(ItemType.brolly));
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/UnknownCharRepresentationExceptionTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/UnknownCharRepresentationExceptionTest.java
@@ -1,0 +1,11 @@
+package rabbitescape.engine.things.items;
+
+import org.junit.Test;
+
+public class UnknownCharRepresentationExceptionTest {
+
+    @Test(expected = UnknownCharRepresentationException.class)
+    public void throwException() {
+        throw new UnknownCharRepresentationException();
+    }
+}

--- a/rabbit-escape-engine/test/rabbitescape/engine/things/items/UnknownItemTypeExceptionTest.java
+++ b/rabbit-escape-engine/test/rabbitescape/engine/things/items/UnknownItemTypeExceptionTest.java
@@ -1,0 +1,11 @@
+package rabbitescape.engine.things.items;
+
+import org.junit.Test;
+
+public class UnknownItemTypeExceptionTest {
+
+    @Test(expected = UnknownItemTypeException.class)
+    public void throwException() {
+        throw new UnknownItemTypeException(BashItem.TYPE);
+    }
+}


### PR DESCRIPTION
Added Items' test cases (w/o states)
- added "empty" in ItemType Enum to create a test case which throws UnknownItemTypeException in ItemFactory

Added ItemStates' test cases
- newState(BehaviorTools, boolean) method in ItemState could not be tested since it's not related to Items